### PR TITLE
fix compatibility with ntp clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm i ntp2
 const ntp = require('ntp2');
 
 ntp.time(function(err, response){
-  console.log('The network time is :', response.time);
+  console.log('The network time is :', new Date(response.toMsecs(response.transmitTimestamp)));
 });
 ```
 
@@ -27,8 +27,7 @@ sntp server
 const ntp = require('ntp2');
 
 const server = ntp.createServer(function(message, response){
-  console.log('server message:', message);
-  message.transmitTimestamp = Date.now();
+  console.log('response message:', message);
   response(message);
 }).listen(123, function(err){
   console.log('server is running at %s', server.address().port);

--- a/example/index.js
+++ b/example/index.js
@@ -2,7 +2,7 @@ const ntp = require('..');
 
 // ntp(function(err, response){
 //   if(err) return console.error(err);
-//   console.log('The network time is :', response.time);
+//   console.log('The network time is :', new Date(response.toMsecs(response.transmitTimestamp)));
 // });
 
 

--- a/example/index.js
+++ b/example/index.js
@@ -8,6 +8,6 @@ const ntp = require('..');
 
 (async () => {
   const n = ntp();
-  const time = await n.time();
-  console.log(time.time);
+  const message = await n.time();
+  console.log(new Date(message.toMsecs(message.transmitTimestamp)));
 })();

--- a/example/server.js
+++ b/example/server.js
@@ -2,7 +2,8 @@ const ntp = require('..');
 
 const server = ntp.createServer(function(message, response){
   console.log('server message:', message);
-  message.transmitTimestamp = Date.now();
+  // By default the current time will be send. Uncomment for custom time
+  // message.writeMsecs(message.transmitTimestamp, (new Date('December 17, 1995 03:24:00')).getTime());
   response(message);
 }).listen(4567, function(err){
   console.log('server is running at %s', server.address().port);

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ NTP.prototype.time = function (callback) {
 NTP.createPacket = function () {
   const packet = new Packet();
   packet.mode = Packet.MODES.CLIENT;
-  packet.originateTimestamp = Date.now();
+  packet.writeMsecs(packet.originateTimestamp, Date.now());
   return packet.toBuffer();
 };
 
@@ -103,18 +103,16 @@ NTP.parse = function (buffer) {
   // date.setUTCSeconds(epoch);
   // return date;
   const message = Packet.parse(buffer);
-  message.destinationTimestamp = Date.now();
-  message.time = new Date(message.transmitTimestamp);
   // Timestamp Name          ID   When Generated
   // ------------------------------------------------------------
   // Originate Timestamp     T1   time request sent by client
   // Receive Timestamp       T2   time request received by server
   // Transmit Timestamp      T3   time reply sent by server
   // Destination Timestamp   T4   time reply received by client
-  const T1 = message.originateTimestamp;
-  const T2 = message.receiveTimestamp;
-  const T3 = message.transmitTimestamp;
-  const T4 = message.destinationTimestamp;
+  const T1 = message.toMsecs(message.originateTimestamp);
+  const T2 = message.toMsecs(message.receiveTimestamp);
+  const T3 = message.toMsecs(message.transmitTimestamp);
+  const T4 = message.toMsecs(Date.now());
   // The roundtrip delay d and system clock offset t are defined as:
   // -
   // d = (T4 - T1) - (T3 - T2)     t = ((T2 - T1) + (T3 - T4)) / 2

--- a/server.js
+++ b/server.js
@@ -33,12 +33,16 @@ class NTPServer extends EventEmitter {
       message.mode = Packet.MODES.SERVER; // mark mode as server
       message = message.toBuffer();
     }
-    this.socket.send(message, rinfo.port, rinfo.server, callback);
+    this.socket.send(message, rinfo.port, rinfo.address, callback);
     return this;
   }
   parse(message, rinfo) {
     const packet = Packet.parse(message);
-    packet.receiveTimestamp = Date.now();
+    packet.stratum = 1;
+    packet.transmitTimestamp.copy(packet.originateTimestamp);
+    packet.writeMsecs(packet.receiveTimestamp, Date.now());
+    packet.receiveTimestamp.copy(packet.referenceTimestamp);
+    packet.writeMsecs(packet.transmitTimestamp, Date.now());
     this.emit('request', packet, this.send.bind(this, rinfo));
     return this;
   }


### PR DESCRIPTION
NTP clients expect TransmitTimestamp == OriginTimestamp which was not possible with the current implementation due to rounding errors. The binary value was always off by a bit and NTP clients rejected the response.

This PR also fixes the issue with newer Node versions which expect the "address" instead of the "server" property.

Ref: The problematic check inside of ntpd in BusyBox: https://git.busybox.net/busybox/tree/networking/ntpd.c#n1869

I verified the fix with ntpd on BusyBox and sntp on MacOS.